### PR TITLE
refactor(auth): centralise tenant header injection via config.injectT…

### DIFF
--- a/frontend/docs/FE_AUTH_FLOW.md
+++ b/frontend/docs/FE_AUTH_FLOW.md
@@ -1,4 +1,4 @@
-_Last updated: 2026-04-11 15:00 UTC_
+_Last updated: 2026-04-16 00:00 UTC_
 
 # FE Auth Flow
 
@@ -59,7 +59,7 @@ Every API call goes through the centralised fetch wrapper in `packages/api-clien
 fetcher(url, options)             (packages/api-client/core/fetcher.ts)
   → getAccessToken()              reads from Zustand store (packages/auth/store/index.ts)
   → Authorization: Bearer <token> attached to every request
-  → if appEnv === "development"
+  → if config.injectTenantHeader  (true when appEnv === "development" or "staging")
       → getTenantSubdomain()      reads from store
       → X-Tenant-Subdomain header attached
   → fetch(url, { ...options, headers })

--- a/frontend/packages/api-client/core/fetcher.ts
+++ b/frontend/packages/api-client/core/fetcher.ts
@@ -31,7 +31,7 @@ async function _fetcher<T>(
         headers.set("Authorization", `Bearer ${token}`);
     }
 
-    if (config.appEnv === "development") {
+    if (config.injectTenantHeader) {
         const subdomain = getTenantSubdomain();
         if (subdomain) {
             headers.set("X-Tenant-Subdomain", subdomain);

--- a/frontend/packages/auth/utils/index.ts
+++ b/frontend/packages/auth/utils/index.ts
@@ -1,4 +1,5 @@
 // JWT decode helpers and token expiry checks.
+import { config } from "@repo/config";
 
 /** Decodes the payload of a JWT without verifying the signature. */
 export function decodeJwtPayload(token: string): Record<string, unknown> {
@@ -24,7 +25,7 @@ export function isTokenExpired(token: string): boolean {
 
 /** Builds fetch headers for auth service requests.
  *  accessToken     → Authorization: Bearer <token>
- *  tenantSubdomain → X-Tenant-Subdomain (only in local/development environments)
+ *  tenantSubdomain → X-Tenant-Subdomain (only in development/staging environments)
  */
 export function buildAuthHeaders(
     accessToken?: string | null,
@@ -32,8 +33,7 @@ export function buildAuthHeaders(
 ): Record<string, string> {
     const headers: Record<string, string> = { "Content-Type": "application/json" };
     if (accessToken) headers["Authorization"] = `Bearer ${accessToken}`;
-    const env = import.meta.env.VITE_APP_ENV;
-    if (tenantSubdomain && (env === "local" || env === "development" || env === "staging")) {
+    if (tenantSubdomain && config.injectTenantHeader) {
         headers["X-Tenant-Subdomain"] = tenantSubdomain;
     }
     return headers;

--- a/frontend/packages/config/index.ts
+++ b/frontend/packages/config/index.ts
@@ -13,6 +13,7 @@ const env = parseEnv(rawEnv);
 export const config = {
     apiBaseUrl: env.VITE_API_BASE_URL,
     appEnv: env.VITE_APP_ENV,
+    injectTenantHeader: env.VITE_APP_ENV === "development" || env.VITE_APP_ENV === "staging",
 } as const;
 
 export type Config = typeof config;


### PR DESCRIPTION
…enantHeader

Replace ad-hoc appEnv/VITE_APP_ENV checks in fetcher and auth utils with a single derived flag on the config object that is true for development and staging environments. Updates FE_AUTH_FLOW.md to reflect the change.